### PR TITLE
Fix ESLint failure on Windows due to minimatch v10 override and add lint to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
+    - run: npm run lint
     - run: npm run build --verbose
       timeout-minutes: 10
     - run: npm run test --verbose

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/microsoft/DynamicProto-JS#readme",
   "overrides": {
-    "minimatch": ">=3.1.2"
+    "minimatch": "~3.1.2"
   },
   "dependencies": {
     "@nevware21/ts-utils": ">= 0.14.0 < 2.x"


### PR DESCRIPTION
The minimatch override in package.json used >=3.1.2 (unbounded) to address a ReDoS vulnerability, which allowed npm to resolve minimatch to v10.x. Minimatch v10 changed backslash handling: backslashes are now treated as escape characters by default, not path separators. ESLint v8's FileEnumerator calls path.resolve() on glob patterns, producing Windows paths like C:\...\lib\src\**\*.ts, then passes them to minimatch without the windowsPathsNoEscape option. This causes glob matching to silently fail — no .ts files are found — and grunt dynamicproto errors out with 'No files matching ./lib/src/**/*.ts were found.'

Fix: constrain the override to ~3.1.2 (3.1.x only, currently 3.1.5). The ReDoS security fix is included, and backslashes still work as path separators, which is what ESLint v8 expects.

Also adds an explicit 'npm run lint' step to the CI workflow so ESLint failures are caught in PR builds before the build step.