### PR TITLE
fix: resolve audit vulns via overrides and add Puppeteer Edge fallback

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,4 +1,29 @@
 module.exports = function (grunt) {
+    // Resolve a Puppeteer executable to use for the QUnit browser tests.
+    // On locally managed Windows devices, Defender/WDAC may block the unsigned
+    // Chromium that Puppeteer downloads to $HOME/.cache/puppeteer ("blocked by
+    // IT admin"). Falling back to the installed Microsoft Edge avoids that.
+    // Gated so CI / official builds keep using the bundled Chromium.
+    function _getBrowserExecutablePath() {
+        if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+            return process.env.PUPPETEER_EXECUTABLE_PATH;
+        }
+        if (process.env.TF_BUILD || process.env.CI || process.env.BUILD_BUILDID) {
+            return undefined; // CI => use bundled Chromium
+        }
+        var candidates = [
+            process.env["ProgramFiles(x86)"] + "\\Microsoft\\Edge\\Application\\msedge.exe",
+            process.env["ProgramFiles"] + "\\Microsoft\\Edge\\Application\\msedge.exe"
+        ];
+        for (var i = 0; i < candidates.length; i++) {
+            if (candidates[i] && grunt.file.exists(candidates[i])) {
+                return candidates[i];
+            }
+        }
+        return undefined;
+    }
+    var browserExecutablePath = _getBrowserExecutablePath();
+
     grunt.initConfig({
         "eslint-ts": {
             default: {
@@ -61,6 +86,7 @@ module.exports = function (grunt) {
                         headless: "new",
                         timeout: 30000,
                         ignoreHTTPErrors: true,
+                        executablePath: browserExecutablePath,
                         args: [
                             "--enable-precise-memory-info",
                             "--expose-internals-for-testing",
@@ -83,6 +109,7 @@ module.exports = function (grunt) {
                         headless: "new",
                         timeout: 30000,
                         ignoreHTTPErrors: true,
+                        executablePath: browserExecutablePath,
                         args: [
                             "--enable-precise-memory-info",
                             "--expose-internals-for-testing",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "linkify-it": "^5.0.2",
     "markdown-it": "^14.3.0",
     "morgan": "^1.11.0",
-    "ws": "^7.5.13"
+    "ws": "^7.5.13",
+    "@types/node": "20.14.2"
   },
   "dependencies": {
     "@nevware21/ts-utils": ">= 0.14.0 < 2.x"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,16 @@
   },
   "homepage": "https://github.com/microsoft/DynamicProto-JS#readme",
   "overrides": {
-    "minimatch": "~3.1.2"
+    "minimatch": "~3.1.2",
+    "brace-expansion": "^1.1.18",
+    "js-yaml": "^4.3.1",
+    "grunt": {
+      "js-yaml": "^3.15.1"
+    },
+    "linkify-it": "^5.0.2",
+    "markdown-it": "^14.3.0",
+    "morgan": "^1.11.0",
+    "ws": "^7.5.13"
   },
   "dependencies": {
     "@nevware21/ts-utils": ">= 0.14.0 < 2.x"


### PR DESCRIPTION
- Add durable overrides for brace-expansion, js-yaml (nested 3.x for grunt), linkify-it, markdown-it, morgan and ws to clear 7 npm audit findings (0 vulnerabilities).

- gruntfile: add CI-gated _getBrowserExecutablePath() helper that falls back to installed Microsoft Edge locally (avoids Defender/WDAC blocking Puppeteer's unsigned Chromium); returns undefined under TF_BUILD/CI so official builds keep bundled Chromium. Wire executablePath into both puppeteer blocks.